### PR TITLE
Socket fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+main/examples/__pycache__

--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -1,0 +1,4 @@
+2024.11.18  Mónica Gómez (Autumn64):
+    - Modificado `clnt_connection` por `self.client_socket` para que la conexión servidor-cliente
+    se haga correctamente. Al ser `clnt_connection` una tupla no se puede utilizar para la
+    recepción de mensajes.

--- a/main/examples/client.py
+++ b/main/examples/client.py
@@ -10,11 +10,10 @@ clnt.connect()
 while True:
     data = clnt.recv(2048,"utf-8")
     print(data)
-    rspns = input("[SrvPy]> ")
+    rspns = input("[ClntPy]> ")
     if rspns == "close":
         #We stop the client
         clnt.disconnect()
-    else: continue
     clnt.send(rspns)
 
 clnt.disconnect()

--- a/main/servpy.py
+++ b/main/servpy.py
@@ -1,13 +1,14 @@
 import socket
 
 class Server:
-    def __init__(self,HOST=str(),PORT=int(),IPvX=int(),PROTO=str(),NUM_DEVICES=int()):
+    def __init__(self,HOST: str,PORT: int,IPvX: int,PROTO: int,NUM_DEVICES: int):
         self._server = None
         self._host = HOST
         self._port = PORT
         self._proto = PROTO
         self._ipvx = IPvX
-        self._num_devices = NUM_DEVICES        
+        self._num_devices = NUM_DEVICES    
+        self.client_socket = None    
         if IPvX == 4:
             if PROTO == "tcp":
                 try:
@@ -45,8 +46,8 @@ class Server:
                 self._server.bind((self._host,self._port))
                 self._server.listen(self._num_devices)
                 global clnt_connection 
-                (client_socket, client_addr) = self._server.accept()
-                clnt_connection = (client_socket, client_addr)
+                self.client_socket, client_addr = self._server.accept()
+                clnt_connection = (self.client_socket, client_addr)
             except socket.error as e:
                 print(f"ERROR TURNNING ON SERVER: {e}")
         else:
@@ -65,7 +66,7 @@ class Server:
         if self._server:
             if INDATA is not None:
                 try:
-                    packet = self._server.recv(INDATA).decode(DECODING)
+                    packet = self.client_socket.recv(INDATA).decode(DECODING)
                     return packet
                 except Exception as e:
                     print(f"ERROR RECIVING DATA: {e}")


### PR DESCRIPTION
Es incorrecto usar `self._server` para la recepción de información puesto que es únicamente la instancia del servidor para los sockets. Lo que se debe de utilizar en su lugar es la conexión con el cliente, la cual era la variable `client_socket` contenida en una tupla llamada `clnt_connection`. Para poder usar la conexión la convertí en una variable de la propia clase con `self.client_socket` y, desde ahí, se realiza la recepción de datos.